### PR TITLE
feat(general): cargo nightly, force repr c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,10 +36,11 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "cbindgen"
-version = "0.20.0"
+version = "0.20.0-rainway.0"
 dependencies = [
  "clap",
  "heck",
+ "home",
  "indexmap",
  "log",
  "proc-macro2",
@@ -115,6 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "cbindgen"
-version = "0.20.0"
+version = "0.20.0-rainway.0"
 authors = [
   "Emilio Cobos Álvarez <emilio@crisal.io>",
   "Jeff Muizelaar <jmuizelaar@mozilla.com>",
   "Kartikaya Gupta <kats@mozilla.com>",
-  "Ryan Hunt <rhunt@eqrion.net>"
+  "Ryan Hunt <rhunt@eqrion.net>",
+  "Ben Greenier <ben@rainway.com>"
 ]
 license = "MPL-2.0"
 description = "A tool for generating C bindings to Rust code."
@@ -31,6 +32,7 @@ toml = "0.5"
 proc-macro2 = "1"
 quote = "1"
 heck = "0.3"
+home = "0.5.3"
 
 [dependencies.syn]
 version = "1.0.3"

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -237,6 +237,12 @@ impl Builder {
     }
 
     #[allow(unused)]
+    pub fn with_parse_expand_nightly_toolchain(mut self, use_nightly_toolchain: bool) -> Builder {
+        self.config.parse.expand.nightly_toolchain = use_nightly_toolchain;
+        self
+    }
+
+    #[allow(unused)]
     pub fn with_parse_expand_profile(mut self, profile: Profile) -> Builder {
         self.config.parse.expand.profile = profile;
         self

--- a/src/bindgen/cargo/cargo.rs
+++ b/src/bindgen/cargo/cargo.rs
@@ -4,6 +4,8 @@
 
 use std::path::{Path, PathBuf};
 
+use home::cargo_home;
+
 use crate::bindgen::cargo::cargo_expand;
 use crate::bindgen::cargo::cargo_lock::{self, Lock};
 pub(crate) use crate::bindgen::cargo::cargo_metadata::PackageRef;
@@ -237,6 +239,7 @@ impl Cargo {
         expand_default_features: bool,
         expand_features: &Option<Vec<String>>,
         profile: Profile,
+        use_nightly: bool,
     ) -> Result<String, cargo_expand::Error> {
         cargo_expand::expand(
             &self.manifest_path,
@@ -247,6 +250,19 @@ impl Cargo {
             expand_default_features,
             expand_features,
             profile,
+            use_nightly,
         )
+    }
+
+    pub(crate) fn path() -> Result<String, std::io::Error> {
+        let mut cargo_path = cargo_home()?.join("bin");
+
+        if cfg!(windows) {
+            cargo_path = cargo_path.join("cargo.exe");
+        } else {
+            cargo_path = cargo_path.join("cargo");
+        }
+
+        Ok(cargo_path.to_str().unwrap().to_owned())
     }
 }

--- a/src/bindgen/cargo/cargo_expand.rs
+++ b/src/bindgen/cargo/cargo_expand.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::bindgen::config::Profile;
+use crate::bindgen::Cargo;
 use std::env;
 use std::error;
 use std::fmt;
@@ -68,8 +69,9 @@ pub fn expand(
     expand_default_features: bool,
     expand_features: &Option<Vec<String>>,
     profile: Profile,
+    use_nightly: bool,
 ) -> Result<String, Error> {
-    let cargo = env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
+    let cargo = Cargo::path().unwrap_or_else(|_| String::from("cargo"));
     let mut cmd = Command::new(cargo);
 
     let mut _temp_dir = None; // drop guard
@@ -90,7 +92,12 @@ pub fn expand(
     // cbindgen
     cmd.env("_CBINDGEN_IS_RUNNING", "1");
 
+    if use_nightly {
+        cmd.arg("+nightly");
+    }
+
     cmd.arg("rustc");
+
     cmd.arg("--lib");
     // When build with the release profile we can't choose the `check` profile.
     if profile != Profile::Release {

--- a/src/bindgen/cargo/cargo_metadata.rs
+++ b/src/bindgen/cargo/cargo_metadata.rs
@@ -21,6 +21,8 @@ use std::path::Path;
 use std::process::{Command, Output};
 use std::str::Utf8Error;
 
+use crate::bindgen::Cargo;
+
 #[derive(Clone, Deserialize, Debug)]
 /// Starting point for metadata returned by `cargo metadata`
 pub struct Metadata {
@@ -235,7 +237,7 @@ pub fn metadata(
                 None
             };
 
-            let cargo = env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
+            let cargo = Cargo::path().unwrap_or_else(|_| String::from("cargo"));
             let mut cmd = Command::new(cargo);
             cmd.arg("metadata");
             cmd.arg("--all-features");

--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -92,12 +92,6 @@ impl CDecl {
                 )
             })
             .collect();
-
-        // apply the convention as a qualifier, if we have one
-        if let Some(conv) = config.function.convention(&f.annotations) {
-            self.type_qualifers = conv;
-        }
-
         self.declarators
             .push(CDeclarator::Func(args, layout_vertical));
         self.build_type(&f.ret, false, config);

--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -92,6 +92,12 @@ impl CDecl {
                 )
             })
             .collect();
+
+        // apply the convention as a qualifier, if we have one
+        if let Some(conv) = config.function.convention(&f.annotations) {
+            self.type_qualifers = conv;
+        }
+
         self.declarators
             .push(CDeclarator::Func(args, layout_vertical));
         self.build_type(&f.ret, false, config);

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -594,8 +594,10 @@ pub struct EnumConfig {
     /// Whether to generate empty, private default-constructors for tagged
     /// enums.
     pub private_default_tagged_enum_constructor: bool,
-    /// Whether to force all enums to use the C layout strategy, as if they have `[repr(C)]
-    pub force_repr_c: bool,
+    /// A list of representation values from https://doc.rust-lang.org/nomicon/other-reprs.html
+    /// that will be treated as if they had `[repr(C)]` instead.
+    /// For example: `["u32", "i32"]` would treat `[repr(u32)]` and `[repr(i32)]` as `[repr(C)]`, respectively.
+    pub force_repr_c: Vec<String>,
 }
 
 impl Default for EnumConfig {
@@ -615,7 +617,7 @@ impl Default for EnumConfig {
             derive_ostream: false,
             enum_class: true,
             private_default_tagged_enum_constructor: false,
-            force_repr_c: false,
+            force_repr_c: vec![],
         }
     }
 }

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -421,6 +421,8 @@ impl LayoutConfig {
 pub struct FunctionConfig {
     /// Optional text to output before each function declaration
     pub prefix: Option<String>,
+    /// Optional calling convention to emit in each function declaration
+    pub convention: Option<String>,
     /// Optional text to output after each function declaration
     pub postfix: Option<String>,
     /// The way to annotation this function as #[must_use]
@@ -441,6 +443,7 @@ impl Default for FunctionConfig {
     fn default() -> FunctionConfig {
         FunctionConfig {
             prefix: None,
+            convention: None,
             postfix: None,
             must_use: None,
             args: Layout::Auto,
@@ -465,6 +468,13 @@ impl FunctionConfig {
             return x;
         }
         self.postfix.clone()
+    }
+
+    pub(crate) fn convention(&self, annotations: &AnnotationSet) -> Option<String> {
+        if let Some(x) = annotations.atom("convention") {
+            return x;
+        }
+        self.convention.clone()
     }
 }
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -421,8 +421,6 @@ impl LayoutConfig {
 pub struct FunctionConfig {
     /// Optional text to output before each function declaration
     pub prefix: Option<String>,
-    /// Optional calling convention to emit in each function declaration
-    pub convention: Option<String>,
     /// Optional text to output after each function declaration
     pub postfix: Option<String>,
     /// The way to annotation this function as #[must_use]
@@ -443,7 +441,6 @@ impl Default for FunctionConfig {
     fn default() -> FunctionConfig {
         FunctionConfig {
             prefix: None,
-            convention: None,
             postfix: None,
             must_use: None,
             args: Layout::Auto,
@@ -468,13 +465,6 @@ impl FunctionConfig {
             return x;
         }
         self.postfix.clone()
-    }
-
-    pub(crate) fn convention(&self, annotations: &AnnotationSet) -> Option<String> {
-        if let Some(x) = annotations.atom("convention") {
-            return x;
-        }
-        self.convention.clone()
     }
 }
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -594,6 +594,8 @@ pub struct EnumConfig {
     /// Whether to generate empty, private default-constructors for tagged
     /// enums.
     pub private_default_tagged_enum_constructor: bool,
+    /// Whether to force all enums to use the C layout strategy, as if they have `[repr(C)]
+    pub force_repr_c: bool,
 }
 
 impl Default for EnumConfig {
@@ -613,6 +615,7 @@ impl Default for EnumConfig {
             derive_ostream: false,
             enum_class: true,
             private_default_tagged_enum_constructor: false,
+            force_repr_c: false,
         }
     }
 }
@@ -755,6 +758,9 @@ pub struct ParseExpandConfig {
     pub features: Option<Vec<String>>,
     /// Controls whether or not to pass `--release` when expanding.
     pub profile: Profile,
+    /// Whether to find and use nightly toolchain for expansion rather than the default.
+    /// This is equivalent to adding `+nightly` to `cargo` when building.
+    pub nightly_toolchain: bool,
 }
 
 impl Default for ParseExpandConfig {
@@ -765,6 +771,7 @@ impl Default for ParseExpandConfig {
             default_features: true,
             features: None,
             profile: Profile::Debug,
+            nightly_toolchain: false,
         }
     }
 }
@@ -797,6 +804,7 @@ fn retrocomp_parse_expand_config_deserialize<'de, D: Deserializer<'de>>(
                 default_features: true,
                 features: None,
                 profile: Profile::Debug,
+                nightly_toolchain: false,
             })
         }
 

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -206,6 +206,7 @@ impl<'a> Parser<'a> {
                         self.config.parse.expand.default_features,
                         &self.config.parse.expand.features,
                         self.config.parse.expand.profile,
+                        self.config.parse.expand.nightly_toolchain,
                     )
                     .map_err(|x| Error::CargoExpand(pkg.name.clone(), x))?;
                 let i = syn::parse_file(&s).map_err(|x| Error::ParseSyntaxError {


### PR DESCRIPTION
feat(repr-c): provides a flag for forcing `[repr(c)]` style layouts
   
This enables us to force `[repr(c)]` which can be useful (we'll use it internally) for forcing enum types to use C style layout, despite having a backing type. For us, the reason we can't easily just change to `[repr(c)]` is that it's in other generated code. We could consider updating that generator to be more specific, but for now this solves for what we need here.

feat(cargo): provides a flag for using `cargo +nightly` for expansion
    
This improves our dev experience where folks have `nightly` installed side by side, but use `stable` as default. Since we need expansion internally for some of our types to come through properly, this removes the need to switch toolchains before installing, instead letting cargo help us out there.
