### PR TITLE
feat(bitflags): Remap bitflag macro => enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbindgen"
-version = "0.20.0-rainway.0"
+version = "0.20.0-rainway.1"
 authors = [
   "Emilio Cobos Álvarez <emilio@crisal.io>",
   "Jeff Muizelaar <jmuizelaar@mozilla.com>",

--- a/src/bindgen/bitflags.rs
+++ b/src/bindgen/bitflags.rs
@@ -61,7 +61,6 @@ impl Bitflags {
         let consts = flags.expand();
 
         let enum_: syn::ItemEnum = parse_quote! {
-            /// cbindgen:internal-derive-bitflags=true
             #(#attrs)*
             #vis enum #name {
                 #consts

--- a/src/bindgen/bitflags.rs
+++ b/src/bindgen/bitflags.rs
@@ -3,7 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use proc_macro2::TokenStream;
+use quote::ToTokens;
 use syn::parse::{Parse, ParseStream, Parser, Result as ParseResult};
+
+use crate::bindgen::ir::Repr;
 
 // $(#[$outer:meta])*
 // ($($vis:tt)*) $BitFlags:ident: $T:ty {
@@ -26,9 +29,9 @@ pub struct Bitflags {
 }
 
 impl Bitflags {
-    pub fn expand(&self) -> (syn::ItemStruct, syn::ItemImpl) {
+    pub fn expand(&mut self, force_repr_c: &[String]) -> syn::ItemEnum {
         let Bitflags {
-            ref attrs,
+            ref mut attrs,
             ref vis,
             ref name,
             ref repr,
@@ -36,22 +39,36 @@ impl Bitflags {
             ..
         } = *self;
 
-        let struct_ = parse_quote! {
+        let repr_name = repr.into_token_stream().to_string();
+
+        if force_repr_c.contains(&repr_name) {
+            if let Some(pos) = attrs
+                .iter()
+                .position(|a| Repr::load(&[a.to_owned()]).is_ok())
+            {
+                info!(
+                    "Bitflags - removing existing repr because force_repr_c includes type {}",
+                    repr_name
+                );
+                attrs.remove(pos);
+            }
+
+            attrs.push(parse_quote! {
+                #[repr(C)]
+            })
+        }
+
+        let consts = flags.expand();
+
+        let enum_: syn::ItemEnum = parse_quote! {
             /// cbindgen:internal-derive-bitflags=true
             #(#attrs)*
-            #vis struct #name {
-                bits: #repr,
-            }
-        };
-
-        let consts = flags.expand(name, repr);
-        let impl_ = parse_quote! {
-            impl #name {
+            #vis enum #name {
                 #consts
             }
         };
 
-        (struct_, impl_)
+        enum_
     }
 }
 
@@ -85,7 +102,7 @@ struct Flag {
 }
 
 impl Flag {
-    fn expand(&self, struct_name: &syn::Ident, repr: &syn::Type) -> TokenStream {
+    fn expand(&self) -> TokenStream {
         let Flag {
             ref attrs,
             ref name,
@@ -94,7 +111,7 @@ impl Flag {
         } = *self;
         quote! {
             #(#attrs)*
-            pub const #name : #struct_name = #struct_name { bits: (#value) as #repr };
+            #name = #value,
         }
     }
 }
@@ -128,10 +145,10 @@ impl Parse for Flags {
 }
 
 impl Flags {
-    fn expand(&self, struct_name: &syn::Ident, repr: &syn::Type) -> TokenStream {
+    fn expand(&self) -> TokenStream {
         let mut ts = quote! {};
         for flag in &self.0 {
-            ts.extend(flag.expand(struct_name, repr));
+            ts.extend(flag.expand());
         }
         ts
     }

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -344,6 +344,12 @@ impl Builder {
         self
     }
 
+    #[allow(unused)]
+    pub fn with_nightly_toolchain(mut self, use_nightly_toolchain: bool) -> Builder {
+        self.config.parse.expand.nightly_toolchain = use_nightly_toolchain;
+        self
+    }
+
     pub fn generate(self) -> Result<Bindings, Error> {
         let mut result = Parse::new();
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -20,8 +20,6 @@ use crate::bindgen::rename::{IdentifierType, RenameRule};
 use crate::bindgen::reserved;
 use crate::bindgen::writer::{ListType, Source, SourceWriter};
 
-use super::ReprType;
-
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum VariantBody {

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -539,32 +539,6 @@ impl Source for Struct {
                 .rename_args
                 .apply("other", IdentifierType::FunctionArg);
 
-            if self
-                .annotations
-                .bool("internal-derive-bitflags")
-                .unwrap_or(false)
-            {
-                if !wrote_start_newline {
-                    wrote_start_newline = true;
-                    out.new_line();
-                }
-                out.new_line();
-                write!(out, "explicit operator bool() const");
-                out.open_brace();
-                write!(out, "return !!bits;");
-                out.close_brace(false);
-
-                out.new_line();
-                write!(out, "{} operator~() const", self.export_name());
-                out.open_brace();
-                write!(out, "return {{static_cast<decltype(bits)>(~bits)}};");
-                out.close_brace(false);
-
-                self.emit_bitflags_binop('|', &other, out);
-                self.emit_bitflags_binop('&', &other, out);
-                self.emit_bitflags_binop('^', &other, out);
-            }
-
             // Generate a serializer function that allows dumping this struct
             // to an std::ostream. It's defined as a friend function inside the
             // struct definition, and doesn't need the `inline` keyword even

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -201,45 +201,6 @@ impl Struct {
             self.documentation.clone(),
         )
     }
-
-    fn emit_bitflags_binop<F: Write>(
-        &self,
-        operator: char,
-        other: &str,
-        out: &mut SourceWriter<F>,
-    ) {
-        out.new_line();
-        write!(
-            out,
-            "{} operator{}(const {}& {}) const",
-            self.export_name(),
-            operator,
-            self.export_name(),
-            other
-        );
-        out.open_brace();
-        write!(
-            out,
-            "return {{static_cast<decltype(bits)>(this->bits {} {}.bits)}};",
-            operator, other
-        );
-        out.close_brace(false);
-
-        out.new_line();
-        write!(
-            out,
-            "{}& operator{}=(const {}& {})",
-            self.export_name(),
-            operator,
-            self.export_name(),
-            other
-        );
-        out.open_brace();
-        write!(out, "*this = (*this {} {});", operator, other);
-        out.new_line();
-        write!(out, "return *this;");
-        out.close_brace(false);
-    }
 }
 
 impl Item for Struct {

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -1021,7 +1021,7 @@ impl Parse {
             return;
         }
 
-        let bitflags = match bitflags::parse(item.mac.tokens.clone()) {
+        let mut bitflags = match bitflags::parse(item.mac.tokens.clone()) {
             Ok(b) => b,
             Err(e) => {
                 warn!("Failed to parse bitflags invocation: {:?}", e);
@@ -1029,11 +1029,7 @@ impl Parse {
             }
         };
 
-        let (struct_, impl_) = bitflags.expand();
-        self.load_syn_struct(config, crate_name, mod_cfg, &struct_);
-        // We know that the expansion will only reference `struct_`, so it's
-        // fine to just do it here instead of deferring it like we do with the
-        // other calls to this function.
-        self.load_syn_assoc_consts_from_impl(crate_name, mod_cfg, &impl_);
+        let bitflag_enum = bitflags.expand(&config.enumeration.force_repr_c);
+        self.load_syn_enum(config, crate_name, mod_cfg, &bitflag_enum);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,10 @@ fn apply_config_overrides<'a>(config: &mut Config, matches: &ArgMatches<'a>) {
     if matches.is_present("d") {
         config.parse.parse_deps = true;
     }
+
+    if matches.is_present("use-nightly-toolchain") {
+        config.parse.expand.nightly_toolchain = true;
+    }
 }
 
 fn load_bindings<'a>(input: &Path, matches: &ArgMatches<'a>) -> Result<Bindings, Error> {
@@ -261,6 +265,13 @@ fn main() {
                 .long("quiet")
                 .help("Report errors only (overrides verbosity options).")
                 .required(false),
+        )
+        .arg(
+            Arg::with_name("use-nightly-toolchain")
+                .long("use-nightly-toolchain")
+                .takes_value(false)
+                .help("Use cargo +nightly for code expansion")
+                .required(false)
         )
         .get_matches();
 

--- a/tests/expectations/associated_in_body.both.c
+++ b/tests/expectations/associated_in_body.both.c
@@ -8,28 +8,27 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-typedef struct StyleAlignFlags {
-  uint8_t bits;
+typedef enum StyleAlignFlags {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 } StyleAlignFlags;
-/**
- * 'auto'
- */
-#define StyleAlignFlags_AUTO (StyleAlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define StyleAlignFlags_NORMAL (StyleAlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define StyleAlignFlags_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
 
-void root(struct StyleAlignFlags flags);
+void root(enum StyleAlignFlags flags);

--- a/tests/expectations/associated_in_body.both.compat.c
+++ b/tests/expectations/associated_in_body.both.compat.c
@@ -8,35 +8,34 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-typedef struct StyleAlignFlags {
-  uint8_t bits;
+typedef enum StyleAlignFlags {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 } StyleAlignFlags;
-/**
- * 'auto'
- */
-#define StyleAlignFlags_AUTO (StyleAlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define StyleAlignFlags_NORMAL (StyleAlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define StyleAlignFlags_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(struct StyleAlignFlags flags);
+void root(enum StyleAlignFlags flags);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/associated_in_body.c
+++ b/tests/expectations/associated_in_body.c
@@ -8,28 +8,27 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-typedef struct {
-  uint8_t bits;
+typedef enum {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 } StyleAlignFlags;
-/**
- * 'auto'
- */
-#define StyleAlignFlags_AUTO (StyleAlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define StyleAlignFlags_NORMAL (StyleAlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define StyleAlignFlags_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
 
 void root(StyleAlignFlags flags);

--- a/tests/expectations/associated_in_body.compat.c
+++ b/tests/expectations/associated_in_body.compat.c
@@ -8,29 +8,28 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-typedef struct {
-  uint8_t bits;
+typedef enum {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 } StyleAlignFlags;
-/**
- * 'auto'
- */
-#define StyleAlignFlags_AUTO (StyleAlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define StyleAlignFlags_NORMAL (StyleAlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define StyleAlignFlags_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/associated_in_body.cpp
+++ b/tests/expectations/associated_in_body.cpp
@@ -7,52 +7,18 @@
 /// Constants shared by multiple CSS Box Alignment properties
 ///
 /// These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
-struct StyleAlignFlags {
-  uint8_t bits;
-
-  explicit operator bool() const {
-    return !!bits;
-  }
-  StyleAlignFlags operator~() const {
-    return {static_cast<decltype(bits)>(~bits)};
-  }
-  StyleAlignFlags operator|(const StyleAlignFlags& other) const {
-    return {static_cast<decltype(bits)>(this->bits | other.bits)};
-  }
-  StyleAlignFlags& operator|=(const StyleAlignFlags& other) {
-    *this = (*this | other);
-    return *this;
-  }
-  StyleAlignFlags operator&(const StyleAlignFlags& other) const {
-    return {static_cast<decltype(bits)>(this->bits & other.bits)};
-  }
-  StyleAlignFlags& operator&=(const StyleAlignFlags& other) {
-    *this = (*this & other);
-    return *this;
-  }
-  StyleAlignFlags operator^(const StyleAlignFlags& other) const {
-    return {static_cast<decltype(bits)>(this->bits ^ other.bits)};
-  }
-  StyleAlignFlags& operator^=(const StyleAlignFlags& other) {
-    *this = (*this ^ other);
-    return *this;
-  }
-  static const StyleAlignFlags AUTO;
-  static const StyleAlignFlags NORMAL;
-  static const StyleAlignFlags START;
-  static const StyleAlignFlags END;
-  static const StyleAlignFlags FLEX_START;
+enum class StyleAlignFlags {
+  /// 'auto'
+  AUTO = 0,
+  /// 'normal'
+  NORMAL = 1,
+  /// 'start'
+  START = (1 << 1),
+  /// 'end'
+  END = (1 << 2),
+  /// 'flex-start'
+  FLEX_START = (1 << 3),
 };
-/// 'auto'
-inline const StyleAlignFlags StyleAlignFlags::AUTO = StyleAlignFlags{ /* .bits = */ (uint8_t)0 };
-/// 'normal'
-inline const StyleAlignFlags StyleAlignFlags::NORMAL = StyleAlignFlags{ /* .bits = */ (uint8_t)1 };
-/// 'start'
-inline const StyleAlignFlags StyleAlignFlags::START = StyleAlignFlags{ /* .bits = */ (uint8_t)(1 << 1) };
-/// 'end'
-inline const StyleAlignFlags StyleAlignFlags::END = StyleAlignFlags{ /* .bits = */ (uint8_t)(1 << 2) };
-/// 'flex-start'
-inline const StyleAlignFlags StyleAlignFlags::FLEX_START = StyleAlignFlags{ /* .bits = */ (uint8_t)(1 << 3) };
 
 extern "C" {
 

--- a/tests/expectations/associated_in_body.pyx
+++ b/tests/expectations/associated_in_body.pyx
@@ -9,17 +9,16 @@ cdef extern from *:
   # Constants shared by multiple CSS Box Alignment properties
   #
   # These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
-  ctypedef struct StyleAlignFlags:
-    uint8_t bits;
-  # 'auto'
-  const StyleAlignFlags StyleAlignFlags_AUTO # = <StyleAlignFlags>{ <uint8_t>0 }
-  # 'normal'
-  const StyleAlignFlags StyleAlignFlags_NORMAL # = <StyleAlignFlags>{ <uint8_t>1 }
-  # 'start'
-  const StyleAlignFlags StyleAlignFlags_START # = <StyleAlignFlags>{ <uint8_t>(1 << 1) }
-  # 'end'
-  const StyleAlignFlags StyleAlignFlags_END # = <StyleAlignFlags>{ <uint8_t>(1 << 2) }
-  # 'flex-start'
-  const StyleAlignFlags StyleAlignFlags_FLEX_START # = <StyleAlignFlags>{ <uint8_t>(1 << 3) }
+  ctypedef enum StyleAlignFlags:
+    # 'auto'
+    AUTO # = 0,
+    # 'normal'
+    NORMAL # = 1,
+    # 'start'
+    START # = (1 << 1),
+    # 'end'
+    END # = (1 << 2),
+    # 'flex-start'
+    FLEX_START # = (1 << 3),
 
   void root(StyleAlignFlags flags);

--- a/tests/expectations/associated_in_body.tag.c
+++ b/tests/expectations/associated_in_body.tag.c
@@ -8,28 +8,27 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-struct StyleAlignFlags {
-  uint8_t bits;
+enum StyleAlignFlags {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 };
-/**
- * 'auto'
- */
-#define StyleAlignFlags_AUTO (StyleAlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define StyleAlignFlags_NORMAL (StyleAlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define StyleAlignFlags_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
 
-void root(struct StyleAlignFlags flags);
+void root(enum StyleAlignFlags flags);

--- a/tests/expectations/associated_in_body.tag.compat.c
+++ b/tests/expectations/associated_in_body.tag.compat.c
@@ -8,35 +8,34 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-struct StyleAlignFlags {
-  uint8_t bits;
+enum StyleAlignFlags {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 };
-/**
- * 'auto'
- */
-#define StyleAlignFlags_AUTO (StyleAlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define StyleAlignFlags_NORMAL (StyleAlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define StyleAlignFlags_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(struct StyleAlignFlags flags);
+void root(enum StyleAlignFlags flags);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/associated_in_body.tag.pyx
+++ b/tests/expectations/associated_in_body.tag.pyx
@@ -9,17 +9,16 @@ cdef extern from *:
   # Constants shared by multiple CSS Box Alignment properties
   #
   # These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
-  cdef struct StyleAlignFlags:
-    uint8_t bits;
-  # 'auto'
-  const StyleAlignFlags StyleAlignFlags_AUTO # = <StyleAlignFlags>{ <uint8_t>0 }
-  # 'normal'
-  const StyleAlignFlags StyleAlignFlags_NORMAL # = <StyleAlignFlags>{ <uint8_t>1 }
-  # 'start'
-  const StyleAlignFlags StyleAlignFlags_START # = <StyleAlignFlags>{ <uint8_t>(1 << 1) }
-  # 'end'
-  const StyleAlignFlags StyleAlignFlags_END # = <StyleAlignFlags>{ <uint8_t>(1 << 2) }
-  # 'flex-start'
-  const StyleAlignFlags StyleAlignFlags_FLEX_START # = <StyleAlignFlags>{ <uint8_t>(1 << 3) }
+  cdef enum StyleAlignFlags:
+    # 'auto'
+    AUTO # = 0,
+    # 'normal'
+    NORMAL # = 1,
+    # 'start'
+    START # = (1 << 1),
+    # 'end'
+    END # = (1 << 2),
+    # 'flex-start'
+    FLEX_START # = (1 << 3),
 
   void root(StyleAlignFlags flags);

--- a/tests/expectations/bitflags.both.c
+++ b/tests/expectations/bitflags.both.c
@@ -8,36 +8,34 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-typedef struct AlignFlags {
-  uint8_t bits;
+typedef enum AlignFlags {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 } AlignFlags;
-/**
- * 'auto'
- */
-#define AlignFlags_AUTO (AlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define AlignFlags_NORMAL (AlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define AlignFlags_START (AlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
 
-typedef struct DebugFlags {
-  uint32_t bits;
+typedef enum DebugFlags {
+  /**
+   * Flag with the topmost bit set of the u32
+   */
+  BIGGEST_ALLOWED = (1 << 31),
 } DebugFlags;
-/**
- * Flag with the topmost bit set of the u32
- */
-#define DebugFlags_BIGGEST_ALLOWED (DebugFlags){ .bits = (uint32_t)(1 << 31) }
 
-void root(struct AlignFlags flags, struct DebugFlags bigger_flags);
+void root(enum AlignFlags flags, enum DebugFlags bigger_flags);

--- a/tests/expectations/bitflags.both.compat.c
+++ b/tests/expectations/bitflags.both.compat.c
@@ -8,43 +8,41 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-typedef struct AlignFlags {
-  uint8_t bits;
+typedef enum AlignFlags {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 } AlignFlags;
-/**
- * 'auto'
- */
-#define AlignFlags_AUTO (AlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define AlignFlags_NORMAL (AlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define AlignFlags_START (AlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
 
-typedef struct DebugFlags {
-  uint32_t bits;
+typedef enum DebugFlags {
+  /**
+   * Flag with the topmost bit set of the u32
+   */
+  BIGGEST_ALLOWED = (1 << 31),
 } DebugFlags;
-/**
- * Flag with the topmost bit set of the u32
- */
-#define DebugFlags_BIGGEST_ALLOWED (DebugFlags){ .bits = (uint32_t)(1 << 31) }
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(struct AlignFlags flags, struct DebugFlags bigger_flags);
+void root(enum AlignFlags flags, enum DebugFlags bigger_flags);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/bitflags.c
+++ b/tests/expectations/bitflags.c
@@ -8,36 +8,34 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-typedef struct {
-  uint8_t bits;
+typedef enum {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 } AlignFlags;
-/**
- * 'auto'
- */
-#define AlignFlags_AUTO (AlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define AlignFlags_NORMAL (AlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define AlignFlags_START (AlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
 
-typedef struct {
-  uint32_t bits;
+typedef enum {
+  /**
+   * Flag with the topmost bit set of the u32
+   */
+  BIGGEST_ALLOWED = (1 << 31),
 } DebugFlags;
-/**
- * Flag with the topmost bit set of the u32
- */
-#define DebugFlags_BIGGEST_ALLOWED (DebugFlags){ .bits = (uint32_t)(1 << 31) }
 
 void root(AlignFlags flags, DebugFlags bigger_flags);

--- a/tests/expectations/bitflags.compat.c
+++ b/tests/expectations/bitflags.compat.c
@@ -8,37 +8,35 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-typedef struct {
-  uint8_t bits;
+typedef enum {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 } AlignFlags;
-/**
- * 'auto'
- */
-#define AlignFlags_AUTO (AlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define AlignFlags_NORMAL (AlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define AlignFlags_START (AlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
 
-typedef struct {
-  uint32_t bits;
+typedef enum {
+  /**
+   * Flag with the topmost bit set of the u32
+   */
+  BIGGEST_ALLOWED = (1 << 31),
 } DebugFlags;
-/**
- * Flag with the topmost bit set of the u32
- */
-#define DebugFlags_BIGGEST_ALLOWED (DebugFlags){ .bits = (uint32_t)(1 << 31) }
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/bitflags.cpp
+++ b/tests/expectations/bitflags.cpp
@@ -7,81 +7,23 @@
 /// Constants shared by multiple CSS Box Alignment properties
 ///
 /// These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
-struct AlignFlags {
-  uint8_t bits;
-
-  explicit operator bool() const {
-    return !!bits;
-  }
-  AlignFlags operator~() const {
-    return {static_cast<decltype(bits)>(~bits)};
-  }
-  AlignFlags operator|(const AlignFlags& other) const {
-    return {static_cast<decltype(bits)>(this->bits | other.bits)};
-  }
-  AlignFlags& operator|=(const AlignFlags& other) {
-    *this = (*this | other);
-    return *this;
-  }
-  AlignFlags operator&(const AlignFlags& other) const {
-    return {static_cast<decltype(bits)>(this->bits & other.bits)};
-  }
-  AlignFlags& operator&=(const AlignFlags& other) {
-    *this = (*this & other);
-    return *this;
-  }
-  AlignFlags operator^(const AlignFlags& other) const {
-    return {static_cast<decltype(bits)>(this->bits ^ other.bits)};
-  }
-  AlignFlags& operator^=(const AlignFlags& other) {
-    *this = (*this ^ other);
-    return *this;
-  }
+enum class AlignFlags {
+  /// 'auto'
+  AUTO = 0,
+  /// 'normal'
+  NORMAL = 1,
+  /// 'start'
+  START = (1 << 1),
+  /// 'end'
+  END = (1 << 2),
+  /// 'flex-start'
+  FLEX_START = (1 << 3),
 };
-/// 'auto'
-static const AlignFlags AlignFlags_AUTO = AlignFlags{ /* .bits = */ (uint8_t)0 };
-/// 'normal'
-static const AlignFlags AlignFlags_NORMAL = AlignFlags{ /* .bits = */ (uint8_t)1 };
-/// 'start'
-static const AlignFlags AlignFlags_START = AlignFlags{ /* .bits = */ (uint8_t)(1 << 1) };
-/// 'end'
-static const AlignFlags AlignFlags_END = AlignFlags{ /* .bits = */ (uint8_t)(1 << 2) };
-/// 'flex-start'
-static const AlignFlags AlignFlags_FLEX_START = AlignFlags{ /* .bits = */ (uint8_t)(1 << 3) };
 
-struct DebugFlags {
-  uint32_t bits;
-
-  explicit operator bool() const {
-    return !!bits;
-  }
-  DebugFlags operator~() const {
-    return {static_cast<decltype(bits)>(~bits)};
-  }
-  DebugFlags operator|(const DebugFlags& other) const {
-    return {static_cast<decltype(bits)>(this->bits | other.bits)};
-  }
-  DebugFlags& operator|=(const DebugFlags& other) {
-    *this = (*this | other);
-    return *this;
-  }
-  DebugFlags operator&(const DebugFlags& other) const {
-    return {static_cast<decltype(bits)>(this->bits & other.bits)};
-  }
-  DebugFlags& operator&=(const DebugFlags& other) {
-    *this = (*this & other);
-    return *this;
-  }
-  DebugFlags operator^(const DebugFlags& other) const {
-    return {static_cast<decltype(bits)>(this->bits ^ other.bits)};
-  }
-  DebugFlags& operator^=(const DebugFlags& other) {
-    *this = (*this ^ other);
-    return *this;
-  }
+enum class DebugFlags {
+  /// Flag with the topmost bit set of the u32
+  BIGGEST_ALLOWED = (1 << 31),
 };
-/// Flag with the topmost bit set of the u32
-static const DebugFlags DebugFlags_BIGGEST_ALLOWED = DebugFlags{ /* .bits = */ (uint32_t)(1 << 31) };
 
 extern "C" {
 

--- a/tests/expectations/bitflags.pyx
+++ b/tests/expectations/bitflags.pyx
@@ -9,22 +9,20 @@ cdef extern from *:
   # Constants shared by multiple CSS Box Alignment properties
   #
   # These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
-  ctypedef struct AlignFlags:
-    uint8_t bits;
-  # 'auto'
-  const AlignFlags AlignFlags_AUTO # = <AlignFlags>{ <uint8_t>0 }
-  # 'normal'
-  const AlignFlags AlignFlags_NORMAL # = <AlignFlags>{ <uint8_t>1 }
-  # 'start'
-  const AlignFlags AlignFlags_START # = <AlignFlags>{ <uint8_t>(1 << 1) }
-  # 'end'
-  const AlignFlags AlignFlags_END # = <AlignFlags>{ <uint8_t>(1 << 2) }
-  # 'flex-start'
-  const AlignFlags AlignFlags_FLEX_START # = <AlignFlags>{ <uint8_t>(1 << 3) }
+  ctypedef enum AlignFlags:
+    # 'auto'
+    AUTO # = 0,
+    # 'normal'
+    NORMAL # = 1,
+    # 'start'
+    START # = (1 << 1),
+    # 'end'
+    END # = (1 << 2),
+    # 'flex-start'
+    FLEX_START # = (1 << 3),
 
-  ctypedef struct DebugFlags:
-    uint32_t bits;
-  # Flag with the topmost bit set of the u32
-  const DebugFlags DebugFlags_BIGGEST_ALLOWED # = <DebugFlags>{ <uint32_t>(1 << 31) }
+  ctypedef enum DebugFlags:
+    # Flag with the topmost bit set of the u32
+    BIGGEST_ALLOWED # = (1 << 31),
 
   void root(AlignFlags flags, DebugFlags bigger_flags);

--- a/tests/expectations/bitflags.tag.c
+++ b/tests/expectations/bitflags.tag.c
@@ -8,36 +8,34 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-struct AlignFlags {
-  uint8_t bits;
+enum AlignFlags {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 };
-/**
- * 'auto'
- */
-#define AlignFlags_AUTO (AlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define AlignFlags_NORMAL (AlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define AlignFlags_START (AlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
 
-struct DebugFlags {
-  uint32_t bits;
+enum DebugFlags {
+  /**
+   * Flag with the topmost bit set of the u32
+   */
+  BIGGEST_ALLOWED = (1 << 31),
 };
-/**
- * Flag with the topmost bit set of the u32
- */
-#define DebugFlags_BIGGEST_ALLOWED (DebugFlags){ .bits = (uint32_t)(1 << 31) }
 
-void root(struct AlignFlags flags, struct DebugFlags bigger_flags);
+void root(enum AlignFlags flags, enum DebugFlags bigger_flags);

--- a/tests/expectations/bitflags.tag.compat.c
+++ b/tests/expectations/bitflags.tag.compat.c
@@ -8,43 +8,41 @@
  *
  * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
  */
-struct AlignFlags {
-  uint8_t bits;
+enum AlignFlags {
+  /**
+   * 'auto'
+   */
+  AUTO = 0,
+  /**
+   * 'normal'
+   */
+  NORMAL = 1,
+  /**
+   * 'start'
+   */
+  START = (1 << 1),
+  /**
+   * 'end'
+   */
+  END = (1 << 2),
+  /**
+   * 'flex-start'
+   */
+  FLEX_START = (1 << 3),
 };
-/**
- * 'auto'
- */
-#define AlignFlags_AUTO (AlignFlags){ .bits = (uint8_t)0 }
-/**
- * 'normal'
- */
-#define AlignFlags_NORMAL (AlignFlags){ .bits = (uint8_t)1 }
-/**
- * 'start'
- */
-#define AlignFlags_START (AlignFlags){ .bits = (uint8_t)(1 << 1) }
-/**
- * 'end'
- */
-#define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
-/**
- * 'flex-start'
- */
-#define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
 
-struct DebugFlags {
-  uint32_t bits;
+enum DebugFlags {
+  /**
+   * Flag with the topmost bit set of the u32
+   */
+  BIGGEST_ALLOWED = (1 << 31),
 };
-/**
- * Flag with the topmost bit set of the u32
- */
-#define DebugFlags_BIGGEST_ALLOWED (DebugFlags){ .bits = (uint32_t)(1 << 31) }
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(struct AlignFlags flags, struct DebugFlags bigger_flags);
+void root(enum AlignFlags flags, enum DebugFlags bigger_flags);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/bitflags.tag.pyx
+++ b/tests/expectations/bitflags.tag.pyx
@@ -9,22 +9,20 @@ cdef extern from *:
   # Constants shared by multiple CSS Box Alignment properties
   #
   # These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
-  cdef struct AlignFlags:
-    uint8_t bits;
-  # 'auto'
-  const AlignFlags AlignFlags_AUTO # = <AlignFlags>{ <uint8_t>0 }
-  # 'normal'
-  const AlignFlags AlignFlags_NORMAL # = <AlignFlags>{ <uint8_t>1 }
-  # 'start'
-  const AlignFlags AlignFlags_START # = <AlignFlags>{ <uint8_t>(1 << 1) }
-  # 'end'
-  const AlignFlags AlignFlags_END # = <AlignFlags>{ <uint8_t>(1 << 2) }
-  # 'flex-start'
-  const AlignFlags AlignFlags_FLEX_START # = <AlignFlags>{ <uint8_t>(1 << 3) }
+  cdef enum AlignFlags:
+    # 'auto'
+    AUTO # = 0,
+    # 'normal'
+    NORMAL # = 1,
+    # 'start'
+    START # = (1 << 1),
+    # 'end'
+    END # = (1 << 2),
+    # 'flex-start'
+    FLEX_START # = (1 << 3),
 
-  cdef struct DebugFlags:
-    uint32_t bits;
-  # Flag with the topmost bit set of the u32
-  const DebugFlags DebugFlags_BIGGEST_ALLOWED # = <DebugFlags>{ <uint32_t>(1 << 31) }
+  cdef enum DebugFlags:
+    # Flag with the topmost bit set of the u32
+    BIGGEST_ALLOWED # = (1 << 31),
 
   void root(AlignFlags flags, DebugFlags bigger_flags);

--- a/tests/profile.rs
+++ b/tests/profile.rs
@@ -75,21 +75,27 @@ fn get_contents_of_dir(path: &Path) -> Vec<String> {
 #[test]
 #[serial]
 fn lib_default_uses_debug_build() {
-    let target_dir = build_using_lib(|b| b);
+    let target_dir = build_using_lib(|b| b.with_nightly_toolchain(true));
     assert_eq!(get_contents_of_dir(target_dir.path()), &["debug"]);
 }
 
 #[test]
 #[serial]
 fn lib_explicit_debug_build() {
-    let target_dir = build_using_lib(|b| b.with_parse_expand_profile(Profile::Debug));
+    let target_dir = build_using_lib(|b| {
+        b.with_parse_expand_profile(Profile::Debug)
+            .with_nightly_toolchain(true)
+    });
     assert_eq!(get_contents_of_dir(target_dir.path()), &["debug"]);
 }
 
 #[test]
 #[serial]
 fn lib_explicit_release_build() {
-    let target_dir = build_using_lib(|b| b.with_parse_expand_profile(Profile::Release));
+    let target_dir = build_using_lib(|b| {
+        b.with_parse_expand_profile(Profile::Release)
+            .with_nightly_toolchain(true)
+    });
     assert_eq!(get_contents_of_dir(target_dir.path()), &["release"]);
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -47,10 +47,13 @@ fn run_cbindgen(
         command.arg("--config").arg(config);
     }
 
+    command.arg("--use-nightly-toolchain");
+
     command.arg(path);
 
     println!("Running: {:?}", command);
     let cbindgen_output = command.output().expect("failed to execute process");
+
     assert!(
         cbindgen_output.status.success(),
         "cbindgen failed: {:?} with error: {}",


### PR DESCRIPTION
Generates enums (respecting `force_repr_c`) for bitflags now, as opposed to the default behavior. This is useful for us at Rainway, as we have some generated bitflags that we'd like to parse, but treat as `enum` for FFI.

Coupled with https://github.com/RainwayApp/bebop/pull/196 this _should_ give us that for our internal types.

